### PR TITLE
Fix example app naming

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,8 +54,9 @@ This script automatically loads apps from the `apps` folder and sends the define
 ## **Structure**  
 
 - [`awtrix_autoScheduler.py`](./awtrix_autoScheduler.py): The main script that starts the scheduler and manages updates.  
-- [`apps`](./apps): Directory containing individual app modules.  
-- [`.env`](./.env): File containing necessary environment variables.  
+- [`apps`](./apps): Directory containing individual app modules.
+- [`demo_apps/example_app.py`](./demo_apps/example_app.py): Sample app that can be copied into `apps`.
+- [`.env`](./.env): File containing necessary environment variables.
 - [`requirements.txt`](./requirements.txt): List of required Python dependencies.  
 
 ## **Features**  

--- a/demo_apps/example_app.py
+++ b/demo_apps/example_app.py
@@ -1,4 +1,4 @@
-# apps/example_app.py
+# demo_apps/example_app.py
 
 """
 Beispiel-App-Skript für AWTRIX.


### PR DESCRIPTION
## Summary
- rename exampe_app.py to example_app.py
- reference demo_apps/example_app.py in README

## Testing
- `python -m py_compile demo_apps/example_app.py awtrix_autoScheduler.py`
